### PR TITLE
Fixed so it runs on IDA Pro 6.6 and above

### DIFF
--- a/BinSourcerer/main.py
+++ b/BinSourcerer/main.py
@@ -72,7 +72,7 @@ class BinSourcererCore():
         ####    self._CfMngr.activateConfiguration()
     
         #Lets start BinSourcerer!
-        self.app = QApplication([])
+        self.app = QApplication.instance()
         self._mainWindow = self._UIMngr.call("MainWindow", self._UIMngr, '')
         self._mainWindow.show()
         self.app.exec_()


### PR DESCRIPTION
PySide is embedded in IDA Pro 6.6 and above.

This fix removes the `A QApplication instance already exists` error at runtime.